### PR TITLE
Update runtime, remove dconf

### DIFF
--- a/net.sourceforge.electrip.Electrip.json
+++ b/net.sourceforge.electrip.Electrip.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.sourceforge.electrip.Electrip",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.32",
+    "runtime-version": "40",
     "sdk": "org.gnome.Sdk",
     "command": "electrip",
     "finish-args": [
@@ -10,10 +10,6 @@
         "--share=network",
         "--filesystem=home",
         "--socket=pulseaudio",
-        "--filesystem=xdg-run/dconf",
-        "--filesystem=~/.config/dconf:ro",
-        "--talk-name=ca.desrt.dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--device=all"
     ],
     "modules": [


### PR DESCRIPTION
This **needs** testing by someone with the device.

Furthermore, after some simple use, it didn't seem to use dconf so I've removed access to it because there's no migration to be done.